### PR TITLE
Template update

### DIFF
--- a/partitions/20190731_bundesbank_publications.json
+++ b/partitions/20190731_bundesbank_publications.json
@@ -9,7 +9,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -19,7 +19,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -29,7 +29,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -39,7 +39,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -51,17 +51,17 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
-    "title": "An analysis of the consistency of banksAo internal ratings",
+    "title": "An analysis of the consistency of banks' internal ratings",
     "datasets": [
       "dataset-005"
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -71,7 +71,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -81,7 +81,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -91,7 +91,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -101,7 +101,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -115,7 +115,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -125,7 +125,7 @@
     ],
     "original": {
       "journal": NaN,
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -137,7 +137,7 @@
     ],
     "original": {
       "journal": "Financial Markets and Portfolio Management (formerly: Finanzmarkt und Portfolio Management)",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -147,7 +147,7 @@
     ],
     "original": {
       "journal": "Review of Finance (formerly: European Finance Review)",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -157,7 +157,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -169,7 +169,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -182,7 +182,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Stability",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -193,7 +193,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -205,7 +205,7 @@
     ],
     "original": {
       "journal": "GERMAN Economic Review",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -215,11 +215,11 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
-    "title": "BanksAo Equity Stakes and Lending: Evidence from a Tax Reform",
+    "title": "Banks' Equity Stakes and Lending: Evidence from a Tax Reform",
     "datasets": [
       "dataset-006",
       "dataset-013",
@@ -228,7 +228,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -238,7 +238,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -248,7 +248,7 @@
     ],
     "original": {
       "journal": "Review of Quantitative Finance and Accounting",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -258,7 +258,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -268,7 +268,7 @@
     ],
     "original": {
       "journal": "Journal of Income Distribution",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -278,7 +278,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -288,7 +288,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -301,7 +301,7 @@
     ],
     "original": {
       "journal": "International Journal of Central Banking",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -311,7 +311,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -322,7 +322,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -332,7 +332,7 @@
     ],
     "original": {
       "journal": "Empirical Economics",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -344,7 +344,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -355,7 +355,7 @@
     ],
     "original": {
       "journal": "Schmollers Jahrbuch",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -365,7 +365,7 @@
     ],
     "original": {
       "journal": "International Journal of Central Banking",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -375,7 +375,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Stability",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -385,7 +385,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -395,7 +395,7 @@
     ],
     "original": {
       "journal": "Applied Economics",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -405,7 +405,7 @@
     ],
     "original": {
       "journal": "Applied Economics",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -415,7 +415,7 @@
     ],
     "original": {
       "journal": " Zeitschrift f\u221a\u00bar Betriebswirtschaft",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -425,7 +425,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -437,7 +437,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -447,7 +447,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -459,7 +459,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -471,7 +471,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -481,7 +481,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -492,7 +492,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -502,7 +502,7 @@
     ],
     "original": {
       "journal": "Review of World Economics",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -512,7 +512,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -522,7 +522,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -532,7 +532,7 @@
     ],
     "original": {
       "journal": "available at SSRN Electronic Journal: https://www.ssrn.com/abstract=2862034",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -542,7 +542,7 @@
     ],
     "original": {
       "journal": "Economic Policy 20 ",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -552,7 +552,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -562,7 +562,7 @@
     ],
     "original": {
       "journal": "International Review of Economics and Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -572,7 +572,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -582,7 +582,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -592,7 +592,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -602,7 +602,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -614,7 +614,7 @@
     ],
     "original": {
       "journal": "Review of Finance (formerly: European Finance Review)",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -624,7 +624,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -634,7 +634,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -644,7 +644,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -655,7 +655,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -666,7 +666,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -676,7 +676,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -686,7 +686,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -696,7 +696,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -706,7 +706,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -717,7 +717,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -727,7 +727,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -737,7 +737,7 @@
     ],
     "original": {
       "journal": NaN,
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -747,7 +747,7 @@
     ],
     "original": {
       "journal": "CESifo DICE Report 4/2015, pp. 41-47",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -757,7 +757,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -767,7 +767,7 @@
     ],
     "original": {
       "journal": "available at SSRN Electronic Journal : https://ssrn.com/abstract=2868283",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -777,7 +777,7 @@
     ],
     "original": {
       "journal": "Journal of Public Economics, volume 156, pp. 131-149",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -789,7 +789,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -799,7 +799,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -809,7 +809,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -819,7 +819,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -829,7 +829,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -839,7 +839,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -850,7 +850,7 @@
     ],
     "original": {
       "journal": "World Economy",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -860,7 +860,7 @@
     ],
     "original": {
       "journal": "The B.E. Journals of Economic Analysis and Policy",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -872,7 +872,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -882,7 +882,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -892,7 +892,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -902,7 +902,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -912,7 +912,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -922,7 +922,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -932,7 +932,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -942,7 +942,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -952,7 +952,7 @@
     ],
     "original": {
       "journal": "Financial Stability Report 2006, Czech National Bank",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -962,7 +962,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -972,7 +972,7 @@
     ],
     "original": {
       "journal": "Czech Journal of Economics and Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -984,7 +984,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -994,7 +994,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1004,7 +1004,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1015,7 +1015,7 @@
     ],
     "original": {
       "journal": "The Journal of Financial Perspectives",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1026,7 +1026,7 @@
     ],
     "original": {
       "journal": "Applied Economics Quarterly",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1036,7 +1036,7 @@
     ],
     "original": {
       "journal": "Quarterly Journal of Economics",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1047,7 +1047,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1057,7 +1057,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1067,7 +1067,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1079,7 +1079,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1089,7 +1089,7 @@
     ],
     "original": {
       "journal": "The review of Economic Studies",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1099,7 +1099,7 @@
     ],
     "original": {
       "journal": "Zeitschrift f\u221a\u00bar betriebswirtschaftliche Forschung",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1109,7 +1109,7 @@
     ],
     "original": {
       "journal": "European Journal of Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1119,7 +1119,7 @@
     ],
     "original": {
       "journal": "available at SSRN Electronic Journal: https://ssrn.com/abstract=3175881",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1129,7 +1129,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1139,7 +1139,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Intermediation",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1149,7 +1149,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1159,7 +1159,7 @@
     ],
     "original": {
       "journal": "CESifo Working Paper No. 2517",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1169,7 +1169,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1179,7 +1179,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1189,7 +1189,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1199,7 +1199,7 @@
     ],
     "original": {
       "journal": "Schmalenbach Business Review",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1210,7 +1210,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1221,7 +1221,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1231,7 +1231,7 @@
     ],
     "original": {
       "journal": "Global Strategy Journal",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1242,7 +1242,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1252,7 +1252,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1262,7 +1262,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1272,7 +1272,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1282,7 +1282,7 @@
     ],
     "original": {
       "journal": " National Tax Journal",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1292,7 +1292,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1303,7 +1303,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1314,7 +1314,7 @@
     ],
     "original": {
       "journal": "IMF Economic Review",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1325,7 +1325,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1335,7 +1335,7 @@
     ],
     "original": {
       "journal": "Taxation in Developing Economics, MIT Press",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1345,7 +1345,7 @@
     ],
     "original": {
       "journal": "The Journal of the Economics of Ageing, Vol. 12.",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1355,7 +1355,7 @@
     ],
     "original": {
       "journal": "American Economic Review",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1365,7 +1365,7 @@
     ],
     "original": {
       "journal": "Canadian Journal of Economics",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1375,7 +1375,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1385,7 +1385,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1395,7 +1395,7 @@
     ],
     "original": {
       "journal": " The Analysis of Firms and Employees: Quantitative and Qualitative Approaches",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1406,7 +1406,7 @@
     ],
     "original": {
       "journal": "Schmollers Jahrbuch",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1416,7 +1416,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1426,7 +1426,7 @@
     ],
     "original": {
       "journal": "Review of World Economics",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1436,7 +1436,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1447,7 +1447,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1459,7 +1459,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1470,7 +1470,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1480,7 +1480,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1491,7 +1491,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1503,7 +1503,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Stability",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1513,7 +1513,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1523,7 +1523,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1533,7 +1533,7 @@
     ],
     "original": {
       "journal": "The Review of Economics and Statistics, volume 98(4), pp. 713\u201a\u00c4\u00ec727",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1543,7 +1543,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1553,7 +1553,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1563,7 +1563,7 @@
     ],
     "original": {
       "journal": "SSRN Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1574,7 +1574,7 @@
     ],
     "original": {
       "journal": "SAFE Working Paper No. 206., available at SSRN: https://ssrn.com/abstract=3174632",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1584,7 +1584,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1594,7 +1594,7 @@
     ],
     "original": {
       "journal": "Journal of the European Economic Association",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1605,7 +1605,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1615,7 +1615,7 @@
     ],
     "original": {
       "journal": " International Tax and Public Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1625,7 +1625,7 @@
     ],
     "original": {
       "journal": "European Journal of Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1637,7 +1637,7 @@
     ],
     "original": {
       "journal": "Financial Markets and Portfolio Management (formerly: Finanzmarkt und Portfolio Management)",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1649,7 +1649,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1661,7 +1661,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1671,7 +1671,7 @@
     ],
     "original": {
       "journal": "Journal of Political Economy (forthcoming), currently available at SSRN Electronic Journal",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1681,7 +1681,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1691,7 +1691,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1704,7 +1704,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Economics",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1714,7 +1714,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1726,7 +1726,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Stability",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1736,7 +1736,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1746,7 +1746,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1756,7 +1756,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1766,7 +1766,7 @@
     ],
     "original": {
       "journal": "ZEW Discussion Paper (No. 18-004)",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1775,28 +1775,18 @@
       "dataset-008"
     ],
     "original": {
-      "journal": " Finanzarchiv",
-      "date_added": "2019-11-11 12:31:11"
+      "journal": "Finanzarchiv",
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
-    "title": "Tax Status and Tax Response Heterogeneity of MultinationalsAo Dept Finance",
-    "datasets": [
-      "dataset-008"
-    ],
-    "original": {
-      "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
-    }
-  },
-  {
-    "title": "Tax vs. Regulation Policy and the Location of ,Financial Sector FDI*",
+    "title": "Tax vs. Regulation Policy and the Location of Financial Sector FDI",
     "datasets": [
       "dataset-008"
     ],
     "original": {
       "journal": "CESifo Working Paper Series No. 5500, available at SSRN Electronic Journal: https://ssrn.com/abstract=2669368",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1805,8 +1795,8 @@
       "dataset-008"
     ],
     "original": {
-      "journal": " Economics Letters",
-      "date_added": "2019-11-11 12:31:11"
+      "journal": "Economics Letters",
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1815,8 +1805,8 @@
       "dataset-008"
     ],
     "original": {
-      "journal": " Review of World Economics (Weltwirtschaftliches Archiv) ",
-      "date_added": "2019-11-11 12:31:11"
+      "journal": "Review of World Economics (Weltwirtschaftliches Archiv) ",
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1826,7 +1816,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1838,7 +1828,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1849,7 +1839,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1859,7 +1849,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1870,7 +1860,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1880,7 +1870,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Stability",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1890,7 +1880,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1900,7 +1890,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1910,7 +1900,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1922,7 +1912,7 @@
     ],
     "original": {
       "journal": "European Financial Management",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1933,7 +1923,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1943,7 +1933,7 @@
     ],
     "original": {
       "journal": " WU International Taxation Research Paper Series (02/2017), available at SSRN Electronic Journal: https://ssrn.com/abstract=2929347)",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1954,17 +1944,17 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
-    "title": "The Effects of MultinationalsAo Profit Shifting Activities on Real Investments",
+    "title": "The Effects of Multinationals' Profit Shifting Activities on Real Investments",
     "datasets": [
       "dataset-008"
     ],
     "original": {
       "journal": "National Tax Journal",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1975,7 +1965,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1985,7 +1975,7 @@
     ],
     "original": {
       "journal": " National Tax Journal",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -1995,7 +1985,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2005,7 +1995,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2016,7 +2006,7 @@
     ],
     "original": {
       "journal": "Munich Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2026,7 +2016,7 @@
     ],
     "original": {
       "journal": "International Tax and Public Finance, volume 16(3), pp. 298-320",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2036,7 +2026,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2046,7 +2036,7 @@
     ],
     "original": {
       "journal": "Journal of Public Economics",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2056,7 +2046,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2066,7 +2056,7 @@
     ],
     "original": {
       "journal": "Journal of Official Statistics",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2076,7 +2066,7 @@
     ],
     "original": {
       "journal": "Journal of Macroeconomics",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2086,7 +2076,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2096,7 +2086,7 @@
     ],
     "original": {
       "journal": "Credit and Capital Markets",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2106,7 +2096,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2116,7 +2106,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2127,7 +2117,7 @@
     ],
     "original": {
       "journal": " available at SSRN Electronic Journal: https://ssrn.com/abstract=31173",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2138,7 +2128,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2148,7 +2138,7 @@
     ],
     "original": {
       "journal": "Strategic Management Journal",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2159,7 +2149,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2171,7 +2161,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2181,7 +2171,7 @@
     ],
     "original": {
       "journal": "Canadian Journal of Economics",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2191,7 +2181,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2201,7 +2191,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2211,7 +2201,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2221,7 +2211,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2231,7 +2221,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2241,7 +2231,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2251,7 +2241,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2262,7 +2252,7 @@
     ],
     "original": {
       "journal": "Beitr\u221a\u00a7ge zur Jahrestagung des Vereins f\u221a\u00bar Socialpolitik",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2272,7 +2262,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2286,7 +2276,7 @@
     ],
     "original": {
       "journal": " Deutsche Bundesbank Discussion Paper (22/2018)",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2296,7 +2286,7 @@
     ],
     "original": {
       "journal": "Journal of Money, Credit and Banking",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2306,7 +2296,7 @@
     ],
     "original": {
       "journal": "Journal of Business Finance and Accounting",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2316,7 +2306,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2328,7 +2318,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2338,7 +2328,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2349,7 +2339,7 @@
     ],
     "original": {
       "journal": "IMF Economic Review",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2359,7 +2349,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2369,7 +2359,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2380,7 +2370,7 @@
     ],
     "original": {
       "journal": NaN,
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2391,7 +2381,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2401,7 +2391,7 @@
     ],
     "original": {
       "journal": "European Economic Review",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2411,7 +2401,7 @@
     ],
     "original": {
       "journal": "International Journal of Banking Account and Finance",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2421,7 +2411,7 @@
     ],
     "original": {
       "journal": "The World Economy",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2431,7 +2421,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2441,7 +2431,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2451,7 +2441,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2463,7 +2453,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2473,7 +2463,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2483,17 +2473,17 @@
     ],
     "original": {
       "journal": "Economic Modelling",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
-    "title": "Why is the Response of MultinationalsAo Capital Structure Choice to Tax Incentives That Low? Some Possible Explanations",
+    "title": "Why is the Response of Multinationals' Capital Structure Choice to Tax Incentives That Low? Some Possible Explanations",
     "datasets": [
       "dataset-008"
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2504,7 +2494,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2514,17 +2504,17 @@
     ],
     "original": {
       "journal": "Economics Letters, vloume 162,pp. 167-170",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
-    "title": "YouAore banned! The effect of sanctions on German cross-border financial flows",
+    "title": "You're banned! The effect of sanctions on German cross-border financial flows",
     "datasets": [
       "dataset-015"
     ],
     "original": {
       "journal": "Economic Policy (formerly: Economic Policy: A European Forum)",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   },
   {
@@ -2534,7 +2524,7 @@
     ],
     "original": {
       "journal": "DIW Vierteljahreshefte zur Wirtschaftsforschung",
-      "date_added": "2019-11-11 12:31:11"
+      "date_added": "2019-11-30 07:21:03"
     }
   }
 ]

--- a/partitions/20190731_bundesbank_publications.json
+++ b/partitions/20190731_bundesbank_publications.json
@@ -9,7 +9,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -19,7 +19,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -29,7 +29,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -39,7 +39,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -51,7 +51,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -61,7 +61,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -71,7 +71,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -81,7 +81,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -91,7 +91,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -101,7 +101,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -115,7 +115,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -125,7 +125,7 @@
     ],
     "original": {
       "journal": NaN,
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -137,7 +137,7 @@
     ],
     "original": {
       "journal": "Financial Markets and Portfolio Management (formerly: Finanzmarkt und Portfolio Management)",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -147,7 +147,7 @@
     ],
     "original": {
       "journal": "Review of Finance (formerly: European Finance Review)",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -157,7 +157,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -169,7 +169,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -182,7 +182,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Stability",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -193,7 +193,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -205,7 +205,7 @@
     ],
     "original": {
       "journal": "GERMAN Economic Review",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -215,7 +215,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -228,7 +228,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -238,7 +238,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -248,7 +248,7 @@
     ],
     "original": {
       "journal": "Review of Quantitative Finance and Accounting",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -258,7 +258,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -268,7 +268,7 @@
     ],
     "original": {
       "journal": "Journal of Income Distribution",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -278,7 +278,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -288,7 +288,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -301,7 +301,7 @@
     ],
     "original": {
       "journal": "International Journal of Central Banking",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -311,7 +311,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -322,7 +322,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -332,7 +332,7 @@
     ],
     "original": {
       "journal": "Empirical Economics",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -344,7 +344,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -355,7 +355,7 @@
     ],
     "original": {
       "journal": "Schmollers Jahrbuch",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -365,7 +365,7 @@
     ],
     "original": {
       "journal": "International Journal of Central Banking",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -375,7 +375,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Stability",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -385,7 +385,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -395,7 +395,7 @@
     ],
     "original": {
       "journal": "Applied Economics",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -405,7 +405,7 @@
     ],
     "original": {
       "journal": "Applied Economics",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -415,17 +415,17 @@
     ],
     "original": {
       "journal": " Zeitschrift f\u221a\u00bar Betriebswirtschaft",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
-    "title": "Corporation Taxes and the Debt Policy of Multinational Firms Ai Evidence from German Multinationals",
+    "title": "Corporation Taxes and the Debt Policy of Multinational Firms -- Evidence from German Multinationals",
     "datasets": [
       "dataset-008"
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -437,7 +437,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -447,7 +447,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -459,7 +459,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -471,7 +471,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -481,7 +481,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -492,7 +492,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -502,7 +502,7 @@
     ],
     "original": {
       "journal": "Review of World Economics",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -512,7 +512,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -522,7 +522,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -532,7 +532,7 @@
     ],
     "original": {
       "journal": "available at SSRN Electronic Journal: https://www.ssrn.com/abstract=2862034",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -542,7 +542,7 @@
     ],
     "original": {
       "journal": "Economic Policy 20 ",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -552,7 +552,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -562,7 +562,7 @@
     ],
     "original": {
       "journal": "International Review of Economics and Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -572,7 +572,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -582,7 +582,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -592,7 +592,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -602,7 +602,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -614,7 +614,7 @@
     ],
     "original": {
       "journal": "Review of Finance (formerly: European Finance Review)",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -624,7 +624,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -634,7 +634,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -644,7 +644,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -655,7 +655,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -666,7 +666,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -676,7 +676,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -686,7 +686,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -696,7 +696,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -706,7 +706,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -717,7 +717,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -727,7 +727,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -737,7 +737,7 @@
     ],
     "original": {
       "journal": NaN,
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -747,7 +747,7 @@
     ],
     "original": {
       "journal": "CESifo DICE Report 4/2015, pp. 41-47",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -757,7 +757,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -767,7 +767,7 @@
     ],
     "original": {
       "journal": "available at SSRN Electronic Journal : https://ssrn.com/abstract=2868283",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -777,7 +777,7 @@
     ],
     "original": {
       "journal": "Journal of Public Economics, volume 156, pp. 131-149",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -789,7 +789,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -799,7 +799,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -809,7 +809,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -819,7 +819,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -829,7 +829,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -839,7 +839,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -850,7 +850,7 @@
     ],
     "original": {
       "journal": "World Economy",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -860,7 +860,7 @@
     ],
     "original": {
       "journal": "The B.E. Journals of Economic Analysis and Policy",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -872,7 +872,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -882,7 +882,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -892,7 +892,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -902,7 +902,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -912,7 +912,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -922,7 +922,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -932,7 +932,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -942,7 +942,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -952,7 +952,7 @@
     ],
     "original": {
       "journal": "Financial Stability Report 2006, Czech National Bank",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -962,7 +962,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -972,7 +972,7 @@
     ],
     "original": {
       "journal": "Czech Journal of Economics and Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -984,7 +984,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -994,7 +994,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1004,7 +1004,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1015,7 +1015,7 @@
     ],
     "original": {
       "journal": "The Journal of Financial Perspectives",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1026,7 +1026,7 @@
     ],
     "original": {
       "journal": "Applied Economics Quarterly",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1036,7 +1036,7 @@
     ],
     "original": {
       "journal": "Quarterly Journal of Economics",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1047,7 +1047,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1057,7 +1057,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1067,7 +1067,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1079,7 +1079,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1089,7 +1089,7 @@
     ],
     "original": {
       "journal": "The review of Economic Studies",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1099,7 +1099,7 @@
     ],
     "original": {
       "journal": "Zeitschrift f\u221a\u00bar betriebswirtschaftliche Forschung",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1109,7 +1109,7 @@
     ],
     "original": {
       "journal": "European Journal of Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1119,17 +1119,17 @@
     ],
     "original": {
       "journal": "available at SSRN Electronic Journal: https://ssrn.com/abstract=3175881",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
-    "title": "How Can Firms choose their Leverage? Ai Tax Planning for Implementing Tax Induced Debt Finance",
+    "title": "How Can Firms choose their Leverage? -- Tax Planning for Implementing Tax Induced Debt Finance",
     "datasets": [
       "dataset-008"
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1139,7 +1139,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Intermediation",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1149,7 +1149,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1159,7 +1159,7 @@
     ],
     "original": {
       "journal": "CESifo Working Paper No. 2517",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1169,7 +1169,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1179,7 +1179,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1189,7 +1189,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1199,7 +1199,7 @@
     ],
     "original": {
       "journal": "Schmalenbach Business Review",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1210,7 +1210,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1221,7 +1221,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1231,7 +1231,7 @@
     ],
     "original": {
       "journal": "Global Strategy Journal",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1242,7 +1242,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1252,7 +1252,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1262,17 +1262,17 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
-    "title": "Intercompany Loans and Profit Shifting Ai Evidence from Company-Level Data",
+    "title": "Intercompany Loans and Profit Shifting -- Evidence from Company-Level Data",
     "datasets": [
       "dataset-008"
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1282,7 +1282,7 @@
     ],
     "original": {
       "journal": " National Tax Journal",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1292,7 +1292,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1303,7 +1303,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1314,7 +1314,7 @@
     ],
     "original": {
       "journal": "IMF Economic Review",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1325,7 +1325,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1335,7 +1335,7 @@
     ],
     "original": {
       "journal": "Taxation in Developing Economics, MIT Press",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1345,7 +1345,7 @@
     ],
     "original": {
       "journal": "The Journal of the Economics of Ageing, Vol. 12.",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1355,7 +1355,7 @@
     ],
     "original": {
       "journal": "American Economic Review",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1365,7 +1365,7 @@
     ],
     "original": {
       "journal": "Canadian Journal of Economics",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1375,7 +1375,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1385,7 +1385,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1395,7 +1395,7 @@
     ],
     "original": {
       "journal": " The Analysis of Firms and Employees: Quantitative and Qualitative Approaches",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1406,7 +1406,7 @@
     ],
     "original": {
       "journal": "Schmollers Jahrbuch",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1416,7 +1416,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1426,7 +1426,7 @@
     ],
     "original": {
       "journal": "Review of World Economics",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1436,7 +1436,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1447,7 +1447,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1459,7 +1459,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1470,7 +1470,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1480,7 +1480,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1491,11 +1491,11 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
-    "title": "Monetary policy and financial (in)stability: An integrated microAimacro approach",
+    "title": "Monetary policy and financial (in)stability: An integrated micro--macro approach",
     "datasets": [
       "dataset-013",
       "dataset-385",
@@ -1503,7 +1503,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Stability",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1513,7 +1513,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1523,7 +1523,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1533,7 +1533,7 @@
     ],
     "original": {
       "journal": "The Review of Economics and Statistics, volume 98(4), pp. 713\u201a\u00c4\u00ec727",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1543,7 +1543,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1553,7 +1553,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1563,7 +1563,7 @@
     ],
     "original": {
       "journal": "SSRN Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1574,7 +1574,7 @@
     ],
     "original": {
       "journal": "SAFE Working Paper No. 206., available at SSRN: https://ssrn.com/abstract=3174632",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1584,7 +1584,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1594,7 +1594,7 @@
     ],
     "original": {
       "journal": "Journal of the European Economic Association",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1605,7 +1605,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1615,7 +1615,7 @@
     ],
     "original": {
       "journal": " International Tax and Public Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1625,7 +1625,7 @@
     ],
     "original": {
       "journal": "European Journal of Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1637,7 +1637,7 @@
     ],
     "original": {
       "journal": "Financial Markets and Portfolio Management (formerly: Finanzmarkt und Portfolio Management)",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1649,7 +1649,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1661,7 +1661,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1671,7 +1671,7 @@
     ],
     "original": {
       "journal": "Journal of Political Economy (forthcoming), currently available at SSRN Electronic Journal",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1681,7 +1681,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1691,7 +1691,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1704,7 +1704,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Economics",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1714,7 +1714,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1726,7 +1726,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Stability",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1736,7 +1736,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1746,7 +1746,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1756,7 +1756,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1766,7 +1766,7 @@
     ],
     "original": {
       "journal": "ZEW Discussion Paper (No. 18-004)",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1776,7 +1776,7 @@
     ],
     "original": {
       "journal": "Finanzarchiv",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1786,17 +1786,17 @@
     ],
     "original": {
       "journal": "CESifo Working Paper Series No. 5500, available at SSRN Electronic Journal: https://ssrn.com/abstract=2669368",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
-    "title": "Taxation and Capital Structure Choice Ai Evidence from a Panel of German Multinationals",
+    "title": "Taxation and Capital Structure Choice -- Evidence from a Panel of German Multinationals",
     "datasets": [
       "dataset-008"
     ],
     "original": {
       "journal": "Economics Letters",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1806,7 +1806,7 @@
     ],
     "original": {
       "journal": "Review of World Economics (Weltwirtschaftliches Archiv) ",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1816,7 +1816,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1828,7 +1828,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1839,7 +1839,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1849,7 +1849,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1860,7 +1860,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1870,7 +1870,7 @@
     ],
     "original": {
       "journal": "Journal of Financial Stability",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1880,7 +1880,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1890,7 +1890,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1900,7 +1900,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1912,7 +1912,7 @@
     ],
     "original": {
       "journal": "European Financial Management",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1923,7 +1923,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1933,7 +1933,7 @@
     ],
     "original": {
       "journal": " WU International Taxation Research Paper Series (02/2017), available at SSRN Electronic Journal: https://ssrn.com/abstract=2929347)",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1944,7 +1944,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1954,7 +1954,7 @@
     ],
     "original": {
       "journal": "National Tax Journal",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1965,7 +1965,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1975,7 +1975,7 @@
     ],
     "original": {
       "journal": " National Tax Journal",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1985,7 +1985,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -1995,7 +1995,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2006,7 +2006,7 @@
     ],
     "original": {
       "journal": "Munich Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2016,7 +2016,7 @@
     ],
     "original": {
       "journal": "International Tax and Public Finance, volume 16(3), pp. 298-320",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2026,7 +2026,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2036,7 +2036,7 @@
     ],
     "original": {
       "journal": "Journal of Public Economics",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2046,7 +2046,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2056,7 +2056,7 @@
     ],
     "original": {
       "journal": "Journal of Official Statistics",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2066,7 +2066,7 @@
     ],
     "original": {
       "journal": "Journal of Macroeconomics",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2076,7 +2076,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2086,7 +2086,7 @@
     ],
     "original": {
       "journal": "Credit and Capital Markets",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2096,7 +2096,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2106,7 +2106,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2117,7 +2117,7 @@
     ],
     "original": {
       "journal": " available at SSRN Electronic Journal: https://ssrn.com/abstract=31173",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2128,7 +2128,7 @@
     ],
     "original": {
       "journal": "Journal of Banking and Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2138,7 +2138,7 @@
     ],
     "original": {
       "journal": "Strategic Management Journal",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2149,7 +2149,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2161,7 +2161,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2171,7 +2171,7 @@
     ],
     "original": {
       "journal": "Canadian Journal of Economics",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2181,7 +2181,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2191,7 +2191,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2201,7 +2201,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2211,7 +2211,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2221,7 +2221,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2231,7 +2231,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2241,7 +2241,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2252,7 +2252,7 @@
     ],
     "original": {
       "journal": "Beitr\u221a\u00a7ge zur Jahrestagung des Vereins f\u221a\u00bar Socialpolitik",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2262,7 +2262,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2276,7 +2276,7 @@
     ],
     "original": {
       "journal": " Deutsche Bundesbank Discussion Paper (22/2018)",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2286,17 +2286,17 @@
     ],
     "original": {
       "journal": "Journal of Money, Credit and Banking",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
-    "title": "Visible Reserves in Banks Ai Determinants of Initial Creation, Usage and Contribution to Bank Stability",
+    "title": "Visible Reserves in Banks -- Determinants of Initial Creation, Usage and Contribution to Bank Stability",
     "datasets": [
       "dataset-006"
     ],
     "original": {
       "journal": "Journal of Business Finance and Accounting",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2306,7 +2306,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2318,7 +2318,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2328,7 +2328,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2339,7 +2339,7 @@
     ],
     "original": {
       "journal": "IMF Economic Review",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2349,7 +2349,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2359,7 +2359,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2370,7 +2370,7 @@
     ],
     "original": {
       "journal": NaN,
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2381,7 +2381,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2391,7 +2391,7 @@
     ],
     "original": {
       "journal": "European Economic Review",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2401,7 +2401,7 @@
     ],
     "original": {
       "journal": "International Journal of Banking Account and Finance",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2411,7 +2411,7 @@
     ],
     "original": {
       "journal": "The World Economy",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2421,7 +2421,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2431,7 +2431,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2441,7 +2441,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2453,7 +2453,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2463,7 +2463,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2473,7 +2473,7 @@
     ],
     "original": {
       "journal": "Economic Modelling",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2483,7 +2483,7 @@
     ],
     "original": {
       "journal": "Working Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2494,7 +2494,7 @@
     ],
     "original": {
       "journal": "BBk Discussion Paper",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2504,7 +2504,7 @@
     ],
     "original": {
       "journal": "Economics Letters, vloume 162,pp. 167-170",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2514,7 +2514,7 @@
     ],
     "original": {
       "journal": "Economic Policy (formerly: Economic Policy: A European Forum)",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   },
   {
@@ -2524,7 +2524,7 @@
     ],
     "original": {
       "journal": "DIW Vierteljahreshefte zur Wirtschaftsforschung",
-      "date_added": "2019-11-30 07:21:03"
+      "date_added": "2019-11-30 07:31:21"
     }
   }
 ]

--- a/publications_export_template.ipynb
+++ b/publications_export_template.ipynb
@@ -93,6 +93,7 @@
     "    x = \" \".join(map(lambda s: s.strip(), text.split(\"\\n\"))).strip()\n",
     "\n",
     "    x = x.replace('“', '\"').replace('”', '\"')\n",
+    "    x = x.replace('‚Äô', \"'\")\n",
     "    x = x.replace(\"‘\", \"'\").replace(\"’\", \"'\").replace(\"`\", \"'\")\n",
     "    x = x.replace(\"`` \", '\"').replace(\"''\", '\"')\n",
     "    x = x.replace('…', '...').replace(\"\\\\u2026\", \"...\")\n",
@@ -285,7 +286,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/publications_export_template.ipynb
+++ b/publications_export_template.ipynb
@@ -93,7 +93,7 @@
     "    x = \" \".join(map(lambda s: s.strip(), text.split(\"\\n\"))).strip()\n",
     "\n",
     "    x = x.replace('“', '\"').replace('”', '\"')\n",
-    "    x = x.replace('‚Äô', \"'\")\n",
+    "    x = x.replace('‚Äô', \"'\").replace('‚Äì',\"--\")\n",
     "    x = x.replace(\"‘\", \"'\").replace(\"’\", \"'\").replace(\"`\", \"'\")\n",
     "    x = x.replace(\"`` \", '\"').replace(\"''\", '\"')\n",
     "    x = x.replace('…', '...').replace(\"\\\\u2026\", \"...\")\n",


### PR DESCRIPTION
Re-exported bundesbank partition to take care of 
https://github.com/NYU-CI/RCPublications/issues/21

Also updated template to replace `‚Äô` and ` ‚Äì`   with appropriate punctuation (the latter not mentioned in your issue but exists in some titles)
