### PR TITLE
catching dicts in linkage csv

### DIFF
--- a/publications_export_template.ipynb
+++ b/publications_export_template.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,16 +51,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "file_name = 'iri_dataset_linkages.csv'\n",
+    "file_name = 'SurveyofEarnedDoctorates_linkages.csv'\n",
     "rcm_subfolder = '20190610_usda_iri'\n",
     "parent_folder = '/Users/sophierand/RichContextMetadata/metadata'\n",
     "linkages_path =  os.path.join(parent_folder,rcm_subfolder,file_name)\n",
-    "# linkages_path =  os.path.join(os.getcwd(),'SNAP_DATA_DIMENSIONS_SEARCH_DEMO.csv')\n",
     "linkages_csv = pd.read_csv(linkages_path)"
    ]
   },
@@ -73,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,6 +190,29 @@
    "metadata": {},
    "source": [
     "Create list of dictionaries of publication metadata. `format_metadata` iterrates through `linkages_csv` dataframe, splits the `dataset` field (for when multiple datasets are listed); throws an error if the dataset doesn't exist and needs to be added to `datasets.json`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def myprint(d):\n",
+    "    for k, v in d.items():\n",
+    "        if \"{\" in v:\n",
+    "            print('Please correct/remove non-string values from {} in your csv for title \"{}\" and rerun.'.format(v,d['title']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linkage_dict_list = linkages_csv.to_dict('records')\n",
+    "for a in linkage_dict_list:\n",
+    "    myprint(a)"
    ]
   },
   {


### PR DESCRIPTION
We're now cleaning all partitions of instances of `{'id': 'jour.1041807', 'title': 'Justice Quarterly'}` but I added a few lines to the template to search for { in the csv and print an alert to the user if so