### PR TITLE
fixes for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .ipynb_checkpoints/*
 .DS_Store
-**/*~
-**/.ipynb_checkpoints
 .RHistory
+*~
+
+__pycache__
+

--- a/test.py
+++ b/test.py
@@ -68,7 +68,6 @@ class TestVerifyPublications (unittest.TestCase):
             for pub in publications:
                 if not set(["title", "datasets"]).issubset(pub.keys()):
                     raise Exception("{}: missing required fields\n{}".format(pub["title"], partition))
-                    # raise Exception("{}: missing required fields\n{}".format(pub["id"], partition))
 
 
     def test_has_valid_url (self):

--- a/test.py
+++ b/test.py
@@ -5,11 +5,13 @@ from urllib.parse import urlparse
 import glob
 import json
 import os
+import pprint
 import sys
 import unittest
 
 
 PARTITIONS = []
+PUBLICATIONS = {}
 
 
 def url_validator (url):
@@ -35,53 +37,70 @@ class TestVerifyPublications (unittest.TestCase):
 
     def setUp (self):
         """load the publications list"""
+        global PUBLICATIONS
+
+        if len(PUBLICATIONS) > 0:
+            self.publications = PUBLICATIONS
+            return
+
         self.publications = {}
+        count = 0
 
         for partition in PARTITIONS:
             with open(partition, "r") as f:
-                print("loading: {}".format(partition))
-                self.publications[partition] = json.load(f)[0]
+                #print("loading: {}".format(partition))
+                self.publications[partition] = json.load(f)
+                count += len(self.publications[partition])
+
+        # store this dictionary in a global variable to prevent
+        # reloading every partition file for every unit test
+        PUBLICATIONS = self.publications
+        print("\n{} publications total".format(count))
 
 
     def test_file_loaded (self):
-        print("\n{} publications loaded".format(len(self.publications)))
+        print("\n{} partitions loaded".format(len(self.publications)))
         self.assertTrue(len(self.publications) > 0)
 
 
     def test_has_required_fields (self):
-        for partition, publication in self.publications.items():
-            if not set(["title", "datasets"]).issubset(publication.keys()):
-                raise Exception("{}: missing required fields\n{}".format(publication["id"], partition))
+        for partition, publications in self.publications.items():
+            for pub in publications:
+                if not set(["title", "datasets"]).issubset(pub.keys()):
+                    raise Exception("{}: missing required fields\n{}".format(pub["id"], partition))
 
 
     def test_has_valid_url (self):
-        for partition, publication in self.publications.items():
-            if "url" in publication:
-                url = publication["url"]
+        for partition, publications in self.publications.items():
+            for pub in publications:
+                if "url" in pub:
+                    url = pub["url"]
 
-                if url == "" or not url:
-                    pass
-                elif not url_validator(url):
-                    raise Exception("{}: badly formed URL {}\n{}".format(publication["title"], url, partition))
+                    if url == "" or not url:
+                        pass
+                    elif not url_validator(url):
+                        raise Exception("{}: badly formed URL {}\n{}".format(pub["title"], url, partition))
 
 
     def test_each_field (self):
-        for partition, publication in self.publications.items():
-            for key in publication.keys():
-                if key not in self.ALLOWED_FIELDS:
-                    raise Exception("{}: unknown field name {}\n{}".format(publication["title"], key, partition))
+        for partition, publications in self.publications.items():
+            for pub in publications:
+                for key in pub.keys():
+                    if key not in self.ALLOWED_FIELDS:
+                        raise Exception("{}: unknown field name {}\n{}".format(pub["title"], key, partition))
 
 
     def test_original_fields (self):
-        for partition, publication in self.publications.items():
-            if "original" in publication.keys():
-                orig = publication["original"]
+        for partition, publications in self.publications.items():
+            for pub in publications:
+                if "original" in pub.keys():
+                    orig = pub["original"]
 
-                for key in ["url", "doi", "pdf", "journal"]:
-                    if key in orig:
-                        if not orig[key] or not isinstance(orig[key], str):
-                            print(orig)
-                            raise Exception("{}: bad value for {}\n{}".format(publication["title"], partition))
+                    for key in ["url", "doi", "pdf", "journal"]:
+                        if key in orig:
+                            if not orig[key] or not isinstance(orig[key], str):
+                                print(orig)
+                                raise Exception("{}: bad value for {}\n{}".format(pub["title"], partition))
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -67,7 +67,8 @@ class TestVerifyPublications (unittest.TestCase):
         for partition, publications in self.publications.items():
             for pub in publications:
                 if not set(["title", "datasets"]).issubset(pub.keys()):
-                    raise Exception("{}: missing required fields\n{}".format(pub["id"], partition))
+                    raise Exception("{}: missing required fields\n{}".format(pub["title"], partition))
+                    # raise Exception("{}: missing required fields\n{}".format(pub["id"], partition))
 
 
     def test_has_valid_url (self):


### PR DESCRIPTION
Fixes for unit tests, so lists of partitions and publications get handled correctly.

NB: this will not initialize correctly with the `nose` test utility. Instead be sure to run it as:

```
python test.py
```

We'll need to be mindful about that while implementing pre-commit Git hooks for this repo.