### PR TITLE
Sophie

### DIFF
--- a/partitions/20191119_ArizonaTemporaryAssistanceforNeedyFamilies_publications.json
+++ b/partitions/20191119_ArizonaTemporaryAssistanceforNeedyFamilies_publications.json
@@ -8,7 +8,7 @@
       "doi": "10.4324/9780203047767",
       "url": "https://doi.org/10.4324/9780203047767",
       "search_term": "Arizona Temporary Assistance for Needy Families",
-      "date_added": "2019-12-30 11:51:40"
+      "date_added": "2019-12-30 12:44:48"
     }
   },
   {
@@ -18,23 +18,23 @@
     ],
     "original": {
       "doi": "10.1002/ev.28",
+      "journal": "New Directions for Evaluation",
       "url": "https://doi.org/10.1002/ev.28",
       "search_term": "Arizona Temporary Assistance for Needy Families",
-      "journal": "New Directions for Evaluation",
-      "date_added": "2019-12-30 11:51:40"
+      "date_added": "2019-12-30 12:44:48"
     }
   },
   {
-    "title": "The Implications of \"Welfare Reform for American Indian Families and Communities",
+    "title": "The Implications of 'Welfare Reform' for American Indian Families and Communities",
     "datasets": [
       "dataset-229"
     ],
     "original": {
       "doi": "10.1300/j134v02n04_01",
+      "journal": "Journal of Poverty",
       "url": "https://doi.org/10.1300/j134v02n04_01",
       "search_term": "Arizona Temporary Assistance for Needy Families",
-      "journal": "Journal of Poverty",
-      "date_added": "2019-12-30 11:51:40"
+      "date_added": "2019-12-30 12:44:48"
     }
   }
 ]

--- a/partitions/20191119_ArizonaTemporaryAssistanceforNeedyFamilies_publications.json
+++ b/partitions/20191119_ArizonaTemporaryAssistanceforNeedyFamilies_publications.json
@@ -8,11 +8,11 @@
       "doi": "10.4324/9780203047767",
       "url": "https://doi.org/10.4324/9780203047767",
       "search_term": "Arizona Temporary Assistance for Needy Families",
-      "date_added": "2019-11-26 10:42:39"
+      "date_added": "2019-12-30 11:51:40"
     }
   },
   {
-    "title": "Managing the transition to selfsufficiency: Changing state policies to provide better support to clients leaving welfare",
+    "title": "Managing the transition to self-sufficiency: Changing state policies to provide better support to clients leaving welfare",
     "datasets": [
       "dataset-229"
     ],
@@ -21,7 +21,7 @@
       "url": "https://doi.org/10.1002/ev.28",
       "search_term": "Arizona Temporary Assistance for Needy Families",
       "journal": "New Directions for Evaluation",
-      "date_added": "2019-11-26 10:42:39"
+      "date_added": "2019-12-30 11:51:40"
     }
   },
   {
@@ -34,7 +34,7 @@
       "url": "https://doi.org/10.1300/j134v02n04_01",
       "search_term": "Arizona Temporary Assistance for Needy Families",
       "journal": "Journal of Poverty",
-      "date_added": "2019-11-26 10:42:39"
+      "date_added": "2019-12-30 11:51:40"
     }
   }
 ]

--- a/partitions/20191119_FloridaWAGES_publications.json
+++ b/partitions/20191119_FloridaWAGES_publications.json
@@ -5,23 +5,23 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.2139/ssrn.3172477",
-      "url": "https://doi.org/10.2139/ssrn.3172477",
-      "search_term": "Florida WAGES",
       "journal": "SSRN Electronic Journal",
-      "date_added": "2019-11-25 10:27:39"
+      "url": "https://doi.org/10.2139/ssrn.3172477",
+      "doi": "10.2139/ssrn.3172477",
+      "search_term": "Florida WAGES",
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
-    "title": "\"In America Life Is Given Away\": Jamaican Farmworkers and the Making of Agricultural Immigration Policy",
+    "title": "'In America Life Is Given Away': Jamaican Farmworkers and the Making of Agricultural Immigration Policy",
     "datasets": [
       "dataset-136"
     ],
     "original": {
-      "doi": "10.7591/9781501717734-009",
       "url": "https://doi.org/10.7591/9781501717734-009",
+      "doi": "10.7591/9781501717734-009",
       "search_term": "Florida WAGES",
-      "date_added": "2019-11-25 10:27:39"
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -30,24 +30,24 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1016/j.jpubeco.2016.08.003",
-      "url": "https://doi.org/10.1016/j.jpubeco.2016.08.003",
-      "search_term": "Florida WAGES",
       "journal": "Journal of Public Economics",
-      "date_added": "2019-11-25 10:27:39"
+      "url": "https://doi.org/10.1016/j.jpubeco.2016.08.003",
+      "doi": "10.1016/j.jpubeco.2016.08.003",
+      "search_term": "Florida WAGES",
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
-    "title": "\"Looking for That Pot of Gold\": The Transnational Life of Kevin Henry",
+    "title": "'Looking for That Pot of Gold': The Transnational Life of Kevin Henry",
     "datasets": [
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1353/eir.2016.0005",
+      "journal": "Eire-Ireland",
       "url": "https://doi.org/10.1353/eir.2016.0005",
+      "doi": "10.1353/eir.2016.0005",
       "search_term": "Florida WAGES",
-      "journal": "\u00c9ire-Ireland",
-      "date_added": "2019-11-25 10:27:39"
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -56,11 +56,11 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1177/000134551406800102",
+      "journal": "Abstracts in Anthropology'}",
       "url": "https://doi.org/10.1177/000134551406800102",
+      "doi": "10.1177/000134551406800102",
       "search_term": "Florida WAGES",
-      "journal": "Abstracts in Anthropology",
-      "date_added": "2019-11-25 10:27:39"
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -69,10 +69,10 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.4324/9780203822692",
       "url": "https://doi.org/10.4324/9780203822692",
+      "doi": "10.4324/9780203822692",
       "search_term": "Florida WAGES",
-      "date_added": "2019-11-25 10:27:39"
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -81,11 +81,11 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1080/0023656x.2012.759806",
+      "journal": "Labor History'}",
       "url": "https://doi.org/10.1080/0023656x.2012.759806",
+      "doi": "10.1080/0023656x.2012.759806",
       "search_term": "Florida WAGES",
-      "journal": "Labor History",
-      "date_added": "2019-11-25 10:27:39"
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -94,11 +94,11 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1016/j.jeca.2012.01.001",
+      "journal": "The Journal of Economic Asymmetries'}",
       "url": "https://doi.org/10.1016/j.jeca.2012.01.001",
+      "doi": "10.1016/j.jeca.2012.01.001",
       "search_term": "Florida WAGES",
-      "journal": "The Journal of Economic Asymmetries",
-      "date_added": "2019-11-25 10:27:39"
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -107,10 +107,10 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.4324/9780203099490",
       "url": "https://doi.org/10.4324/9780203099490",
+      "doi": "10.4324/9780203099490",
       "search_term": "Florida WAGES",
-      "date_added": "2019-11-25 10:27:39"
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -119,11 +119,11 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1111/j.0887-378x.2005.00336.x",
-      "url": "https://doi.org/10.1111/j.0887-378x.2005.00336.x",
-      "search_term": "Florida WAGES",
       "journal": "Milbank Quarterly",
-      "date_added": "2019-11-25 10:27:39"
+      "url": "https://doi.org/10.1111/j.0887-378x.2005.00336.x",
+      "doi": "10.1111/j.0887-378x.2005.00336.x",
+      "search_term": "Florida WAGES",
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -132,11 +132,11 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.2139/ssrn.672664",
-      "url": "https://doi.org/10.2139/ssrn.672664",
-      "search_term": "Florida WAGES",
       "journal": "SSRN Electronic Journal",
-      "date_added": "2019-11-25 10:27:39"
+      "url": "https://doi.org/10.2139/ssrn.672664",
+      "doi": "10.2139/ssrn.672664",
+      "search_term": "Florida WAGES",
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -145,10 +145,10 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1057/9780230524439_4",
       "url": "https://doi.org/10.1057/9780230524439_4",
+      "doi": "10.1057/9780230524439_4",
       "search_term": "Florida WAGES",
-      "date_added": "2019-11-25 10:27:39"
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -157,10 +157,10 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1057/9780230524439",
       "url": "https://doi.org/10.1057/9780230524439",
+      "doi": "10.1057/9780230524439",
       "search_term": "Florida WAGES",
-      "date_added": "2019-11-25 10:27:39"
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -169,11 +169,11 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1300/j045v18n03_01",
-      "url": "https://doi.org/10.1300/j045v18n03_01",
-      "search_term": "Florida WAGES",
       "journal": "Social Work in Public Health",
-      "date_added": "2019-11-25 10:27:39"
+      "url": "https://doi.org/10.1300/j045v18n03_01",
+      "doi": "10.1300/j045v18n03_01",
+      "search_term": "Florida WAGES",
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -182,22 +182,22 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1007/978-3-322-80944-5",
       "url": "https://doi.org/10.1007/978-3-322-80944-5",
+      "doi": "10.1007/978-3-322-80944-5",
       "search_term": "Florida WAGES",
-      "date_added": "2019-11-25 10:27:39"
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
-    "title": "New Labour\", Globalisierung und Sozialpolitik",
+    "title": "'New Labour', Globalisierung und Sozialpolitik",
     "datasets": [
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1007/978-3-322-80944-5_10",
       "url": "https://doi.org/10.1007/978-3-322-80944-5_10",
+      "doi": "10.1007/978-3-322-80944-5_10",
       "search_term": "Florida WAGES",
-      "date_added": "2019-11-25 10:27:39"
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -206,11 +206,11 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1111/1541-0072.00045",
-      "url": "https://doi.org/10.1111/1541-0072.00045",
-      "search_term": "Florida WAGES",
       "journal": "Policy Studies Journal",
-      "date_added": "2019-11-25 10:27:39"
+      "url": "https://doi.org/10.1111/1541-0072.00045",
+      "doi": "10.1111/1541-0072.00045",
+      "search_term": "Florida WAGES",
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -219,11 +219,11 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1177/00914509030301-209",
-      "url": "https://doi.org/10.1177/00914509030301-209",
-      "search_term": "Florida WAGES",
       "journal": "Contemporary Drug Problems",
-      "date_added": "2019-11-25 10:27:39"
+      "url": "https://doi.org/10.1177/00914509030301-209",
+      "doi": "10.1177/00914509030301-209",
+      "search_term": "Florida WAGES",
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -232,11 +232,11 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1177/000134550304600102",
-      "url": "https://doi.org/10.1177/000134550304600102",
-      "search_term": "Florida WAGES",
       "journal": "Abstracts in Anthropology",
-      "date_added": "2019-11-25 10:27:39"
+      "url": "https://doi.org/10.1177/000134550304600102",
+      "doi": "10.1177/000134550304600102",
+      "search_term": "Florida WAGES",
+      "date_added": "2019-12-30 12:10:48"
     }
   },
   {
@@ -245,11 +245,11 @@
       "dataset-136"
     ],
     "original": {
-      "doi": "10.1300/j045v14n02_02",
-      "url": "https://doi.org/10.1300/j045v14n02_02",
-      "search_term": "Florida WAGES",
       "journal": "Social Work in Public Health",
-      "date_added": "2019-11-25 10:27:39"
+      "url": "https://doi.org/10.1300/j045v14n02_02",
+      "doi": "10.1300/j045v14n02_02",
+      "search_term": "Florida WAGES",
+      "date_added": "2019-12-30 12:10:48"
     }
   }
 ]

--- a/scripts/publications_export_template.py
+++ b/scripts/publications_export_template.py
@@ -35,6 +35,9 @@ def scrub_unicode (text):
 
     x = x.replace("\\u2014", " - ").replace('–', '-').replace('—', ' - ')
     x = x.replace("\\u2013", " - ").replace("\\u00ad", " - ")
+    x = x.replace("\\u00C9", "É")
+    x = x.replace('"', "'")
+    
 
     x = str(unicodedata.normalize("NFKD", x).encode("ascii", "ignore").decode("utf-8"))
 
@@ -71,6 +74,12 @@ def create_pub_dict(linkages_dataframe, datasets):
         if len(original_metadata_cols) > 0:
             original_metadata_raw = r[original_metadata_cols].to_dict()
             original_metadata_raw.update({'date_added':datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')})
+            if 'journal' in original_metadata_cols:
+                # print(original_metadata_raw["journal"])
+                try:
+                    original_metadata_raw.update({'journal':scrub_unicode(original_metadata_raw["journal"])})
+                except:
+                    pass
             original_metadata = {k: v for k, v in original_metadata_raw.items() if not pd.isnull(v)}
             pub_dict.update({'original': original_metadata})
         pub_dict_list.append(pub_dict)


### PR DESCRIPTION
I added a line to the export script to handle `É` (and also added a line to run `scrub_unicode` over the journal field but it exported without the accent, as:
`"journal": "Eire-Ireland"` - ideas?


For the ArizonaTANF file:
The title [originated](https://github.com/NYU-CI/RichContextMetadata/blob/master/metadata/20191119_ArizonaTemporaryAssistanceforNeedyFamilies/ArizonaTemporaryAssistanceforNeedyFamilies_linkages_mynoa.csv) as
`The Implications of  ‚ÄúWelfare Reform‚Äû for American Indian Families and Communities`

