### PR TITLE
update readme about original field

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Finally, your CSV file should have the minimum required fields:
 
   * `title` -- title of the publication
   * `dataset` -- a list of links from <https://github.com/NYU-CI/RCDatasets/datasets.json>
-  * `original` -- full metadata extracted from the CSV
+  *  other metadata given such as `doi`. All these files will be stored as a value of the output partition's key `original`
 
 Remove any entries that don't have these fields.
 


### PR DESCRIPTION
I thought that the CSV had 3 columns and one of them must be called original, but this ends up creating a partition with a wrong format (see screenshot below)
![image](https://user-images.githubusercontent.com/2658728/104007171-e1f41900-51ea-11eb-99f6-034a93dd93a9.png)

I have updated the readme to avoid the confusion I had
@ernestogimeno 

